### PR TITLE
Fix: show the latest photo after removing the photo

### DIFF
--- a/src/screens/GalleryScreen.jsx
+++ b/src/screens/GalleryScreen.jsx
@@ -5,7 +5,7 @@ import { Image, Text } from "react-native";
 import MoveToCameraIcon from "../assets/svg/cancel.svg";
 import BackIcon from "../assets/svg/back.svg";
 import DeletePhotoIcon from "../assets/svg/trash.svg";
-
+import { useCameraStore } from "../store/useCameraStore";
 
 const { width: SCREEN_WIDTH, height: SCREEN_HEIGHT } = Dimensions.get('window');
 
@@ -20,6 +20,8 @@ export default function GalleryScreen({ visible, onClose }) {
   const [photos, setPhotos] = useState([]);
   const [selectedUri, setSelectedUri] = useState(null);
   const [isSingleView, setIsSingleView] = useState(false);
+
+  const getLatestPhoto = useCameraStore((state) => state.getLatestPhoto);
 
   const bringPhotos = async () => {
     try {
@@ -41,6 +43,7 @@ export default function GalleryScreen({ visible, onClose }) {
       setSelectedUri(null);
       setIsSingleView(false);
       bringPhotos();
+      await getLatestPhoto();
     } catch (err) {
       console.error("삭제 실패:", err);
     }


### PR DESCRIPTION
## 🚀 PR 유형
어떤 변경 사항이 있나요?

- [X] 버그 수정

## PR 요약
- 앱 갤러리에 접근해서 가장 최신 사진 삭제 후, 기본 프리뷰로 넘어왔을 때, 썸네일 업데이트 실패 
- 최신 사진 삭제 후, 기본 프리뷰로 넘어가도 가장 최신 사진 업데이트 구현 
